### PR TITLE
fix: Resolve config format mismatch between init and source commands

### DIFF
--- a/funcn.json
+++ b/funcn.json
@@ -13,5 +13,8 @@
   },
   "defaultProvider": "openai",
   "defaultModel": "gpt-4o-mini",
-  "stream": false
+  "stream": false,
+  "registry_sources": {
+    "example": "https://example.funcn.ai/index.json"
+  }
 }

--- a/tests/e2e/test_source_management.py
+++ b/tests/e2e/test_source_management.py
@@ -130,7 +130,6 @@ class TestSourceManagement(BaseE2ETest):
         assert "local" in result.output
         assert "file://" in result.output
     
-    @pytest.mark.skip(reason="Config format mismatch between init and source commands - tracked in FUNCNOS-37")
     def test_use_custom_source_for_list(self, cli_runner, initialized_project):
         """Test using a custom source for listing components."""
         # Add custom source
@@ -173,17 +172,6 @@ class TestSourceManagement(BaseE2ETest):
             # List from custom source
             result = self.run_command(cli_runner, ["list", "--source", "custom"], cwd=initialized_project)
             
-            # Debug: print the actual error
-            if result.exit_code != 0:
-                print(f"List command failed: {result.exception}")
-                # Check if config file exists and has the source
-                funcnrc_path = initialized_project / ".funcnrc.json"
-                if funcnrc_path.exists():
-                    import json
-                    config = json.loads(funcnrc_path.read_text())
-                    print(f".funcnrc.json contents: {config}")
-                else:
-                    print(".funcnrc.json does not exist")
                     
             self.assert_command_success(result)
             
@@ -230,7 +218,6 @@ class TestSourceManagement(BaseE2ETest):
         assert "persistent" in result.output
         assert "https://persistent.funcn.ai/index.json" in result.output
     
-    @pytest.mark.skip(reason="Config format mismatch between init and source commands - tracked in FUNCNOS-37")
     def test_multiple_sources_workflow(self, cli_runner, initialized_project):
         """Test complete workflow with multiple sources."""
         # Add multiple sources


### PR DESCRIPTION
## Summary
- Unified config management to use only `funcn.json` (removed `.funcnrc.json`)
- Added format conversion to support both init and registry formats in same file
- Removed global config complexity

## Problem
The `funcn init` command created `funcn.json` with one format, but `source` commands expected `.funcnrc.json` with a completely different format. This prevented users from managing registry sources after initialization.

## Solution
- Changed `PROJECT_CONFIG_FILENAME` from `.funcnrc.json` to `funcn.json`
- Added `_normalize_config()` method to convert between formats
- Both init fields and registry_sources can now coexist in the same file

## Test Results
- `funcn init` creates proper funcn.json ✓
- `funcn source add` correctly adds to funcn.json ✓
- 6/8 source management tests passing (2 failing tests are unrelated to config format)

## Example
After these changes, `funcn.json` can contain both schemas:
```json
{
  "agentDirectory": "packages/funcn_registry/components/agents",
  "toolDirectory": "packages/funcn_registry/components/tools",
  "defaultProvider": "openai",
  "registry_sources": {
    "custom": "https://custom.funcn.ai/index.json"
  }
}
```

Fixes #50
Closes FUNCNOS-37