### PR TITLE
refactor: Remove global config support from source command

### DIFF
--- a/src/funcn_cli/commands/source.py
+++ b/src/funcn_cli/commands/source.py
@@ -14,11 +14,10 @@ app = typer.Typer(help="Manage registry sources.")
 def add(
     alias: str = typer.Argument(..., help="Alias for registry source"),
     url: str = typer.Argument(..., help="URL to index.json of registry"),
-    global_cfg: bool = typer.Option(False, "--global", help="Add source to global config instead of project config."),
 ) -> None:
     """Add a new registry source."""
     cfg_manager = ConfigManager()
-    cfg_manager.add_registry_source(alias, url, project_level=not global_cfg)
+    cfg_manager.add_registry_source(alias, url)
     console.print(f":white_check_mark: Added registry source '{alias}' -> {url}")
 
 

--- a/src/funcn_cli/config_manager.py
+++ b/src/funcn_cli/config_manager.py
@@ -84,15 +84,13 @@ class ConfigManager:
     # Mutating helpers
     # ------------------------------------------------------------------
 
-    def add_registry_source(self, alias: str, url: str, project_level: bool = True) -> None:
-        # Always save to project config (ignore project_level for backward compatibility)
+    def add_registry_source(self, alias: str, url: str) -> None:
         # Reload the config from disk first to preserve existing data
         self._project_cfg = self._load_json(self._project_config_path)
         self._project_cfg.setdefault("registry_sources", {})[alias] = url
         self._save_json(self._project_cfg, self._project_config_path)
 
-    def set_default_registry(self, url: str, project_level: bool = True) -> None:
-        # Always save to project config (ignore project_level for backward compatibility)
+    def set_default_registry(self, url: str) -> None:
         self._project_cfg["default_registry_url"] = url
         self.add_registry_source("default", url)
 

--- a/tests/e2e/test_source_management.py
+++ b/tests/e2e/test_source_management.py
@@ -55,27 +55,6 @@ class TestSourceManagement(BaseE2ETest):
         assert "myregistry" in result.output
         assert "https://myregistry.funcn.ai/index.json" in result.output
     
-    @pytest.mark.skip(reason="Global sources not shown in list - tracked in FUNCNOS-35")
-    def test_add_source_global_level(self, cli_runner, initialized_project):
-        """Test adding a registry source at global level."""
-        # Add a global source
-        result = self.run_command(
-            cli_runner,
-            ["source", "add", "global_registry", "https://global.funcn.ai/index.json", "--global"],
-            cwd=initialized_project
-        )
-        
-        self.assert_command_success(result)
-        
-        # Verify source was added
-        assert "Added registry source" in result.output
-        assert "global_registry" in result.output
-        
-        # Global source should appear in list
-        result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
-        self.assert_command_success(result)
-        
-        assert "global_registry" in result.output
     
     def test_add_duplicate_source(self, cli_runner, initialized_project):
         """Test adding a source with duplicate alias."""


### PR DESCRIPTION
## Summary
Removes the `--global` flag from the source command since we no longer support separate global configuration files.

## Context
We previously unified configuration to use only `funcn.json` (removed `.funcnrc.json`), making the `--global` flag obsolete. All registry sources are now project-scoped.

## Changes
- Remove `--global` flag from 'funcn source add' command  
- Remove `project_level` parameter from ConfigManager methods
- Delete obsolete `test_add_source_global_level` test

## Test Results
All source management tests pass (8 passed, 1 skipped).

## Linear Issue
Closes FUNCNOS-35 (marked as canceled since the feature is no longer applicable)