### PR TITLE
feat: Implement version support for funcn add command

### DIFF
--- a/src/funcn_cli/core/registry_handler.py
+++ b/src/funcn_cli/core/registry_handler.py
@@ -30,37 +30,71 @@ class RegistryHandler:
         data = resp.json()
         return RegistryIndex.model_validate(data)
 
-    def find_component_manifest_url(self, component_name: str, source_alias: str | None = None) -> str | None:
-        """Find component manifest URL in the specified source or all sources."""
+    def find_component_manifest_url(self, component_name: str, version: str | None = None, source_alias: str | None = None) -> str | None:
+        """Find component manifest URL in the specified source or all sources.
+        
+        Args:
+            component_name: Name of the component to find
+            version: Optional version to match (if None, returns latest version)
+            source_alias: Optional specific source to search in
+        """
         if source_alias:
             # Search in specific source
-            return self._search_single_source(component_name, source_alias)
+            return self._search_single_source(component_name, version, source_alias)
         else:
             # Search in all sources, starting with default
             # Try default source first
-            result = self._search_single_source(component_name, None)
+            result = self._search_single_source(component_name, version, None)
             if result:
                 return result
             
             # Try all other configured sources
             for alias in self._cfg.config.registry_sources:
-                result = self._search_single_source(component_name, alias)
+                result = self._search_single_source(component_name, version, alias)
                 if result:
                     console.print(f"[cyan]Found component '{component_name}' in source '{alias}'[/]")
                     return result
             return None
     
-    def _search_single_source(self, component_name: str, source_alias: str | None) -> str | None:
+    def _search_single_source(self, component_name: str, version: str | None, source_alias: str | None) -> str | None:
         """Search for component in a single source."""
         try:
             index = self.fetch_index(source_alias=source_alias)
             url = self._cfg.config.registry_sources.get(source_alias) if source_alias else self._cfg.config.default_registry_url
             
-            for comp in index.components:
-                if comp.name == component_name:
-                    root_url = str(Path(url).parent)
-                    manifest_url = f"{root_url}/{comp.manifest_path}"
-                    return manifest_url
+            # Find all matching components by name
+            matching_components = [comp for comp in index.components if comp.name == component_name]
+            
+            if not matching_components:
+                return None
+            
+            # If version is specified, find exact match
+            if version:
+                for comp in matching_components:
+                    if comp.version == version:
+                        root_url = str(Path(url).parent)
+                        manifest_url = f"{root_url}/{comp.manifest_path}"
+                        return manifest_url
+                return None  # Version not found
+            
+            # If no version specified, find the latest version
+            # Sort by version (assumes semantic versioning)
+            from packaging import version as pkg_version
+            try:
+                sorted_components = sorted(
+                    matching_components,
+                    key=lambda c: pkg_version.parse(c.version),
+                    reverse=True
+                )
+                latest_comp = sorted_components[0]
+            except Exception:
+                # If version parsing fails, just use the first component
+                latest_comp = matching_components[0]
+            
+            root_url = str(Path(url).parent)
+            manifest_url = f"{root_url}/{latest_comp.manifest_path}"
+            return manifest_url
+            
         except Exception as e:
             console.print(f"[yellow]Warning: Failed to search source '{source_alias or 'default'}': {e}[/]")
         return None


### PR DESCRIPTION
## Summary
Implements version support for the `funcn add` command, allowing users to specify component versions using the `@` syntax (e.g., `funcn add component@1.0.0`).

## Changes
- Parse version syntax in `ComponentManager.add_component` to extract component name and version
- Update `RegistryHandler.find_component_manifest_url` to accept optional version parameter
- Implement version matching logic when searching for components
- Add latest version selection when no version is specified (using semantic versioning)
- Add version format validation with clear error messages
- Update and enable previously skipped test
- Add comprehensive tests for edge cases (invalid versions, non-existent versions)

## Test Results
All tests passing:
- ✅ `test_add_component_with_version` - Tests adding a specific version
- ✅ `test_add_component_with_invalid_version_format` - Tests invalid version format handling
- ✅ `test_add_component_with_nonexistent_version` - Tests non-existent version handling
- ✅ All other add workflow tests continue to pass

## Usage
```bash
# Add specific version
funcn add component@1.0.0

# Add latest version (default behavior)
funcn add component

# Invalid version format
funcn add component@invalid-version  # Error: Invalid version format
```

Resolves FUNCNOS-32
Closes #45