### PR TITLE
feat: Add remove subcommand and URL validation to funcn source

### DIFF
--- a/src/funcn_cli/commands/source.py
+++ b/src/funcn_cli/commands/source.py
@@ -4,6 +4,7 @@ import typer
 from funcn_cli.config_manager import ConfigManager
 from rich.console import Console
 from rich.table import Table
+from urllib.parse import urlparse
 
 console = Console()
 
@@ -16,6 +17,23 @@ def add(
     url: str = typer.Argument(..., help="URL to index.json of registry"),
 ) -> None:
     """Add a new registry source."""
+    # Validate URL format
+    parsed = urlparse(url)
+
+    # Check for valid scheme
+    if parsed.scheme not in ("http", "https", "file"):
+        console.print(f":x: Invalid URL scheme '{parsed.scheme}'. Must be http, https, or file.")
+        raise typer.Exit(1)
+
+    # Check for required parts
+    if parsed.scheme in ("http", "https") and not parsed.netloc:
+        console.print(":x: Invalid URL: missing domain/host")
+        raise typer.Exit(1)
+
+    # Warn if URL doesn't end with index.json
+    if not url.endswith("/index.json") and not url.endswith("/index.json/"):
+        console.print(f"[yellow]:warning: URL should typically point to an index.json file. Got: {url}[/yellow]")
+
     cfg_manager = ConfigManager()
     cfg_manager.add_registry_source(alias, url)
     console.print(f":white_check_mark: Added registry source '{alias}' -> {url}")
@@ -29,12 +47,35 @@ def list_sources() -> None:
     table = Table(title="Registry Sources")
     table.add_column("Alias", style="cyan")
     table.add_column("URL")
-    
+
     # Show default source first if not already in registry_sources
     if "default" not in cfg.registry_sources and cfg.default_registry_url:
         table.add_row("[bold]default[/]", cfg.default_registry_url)
-    
+
     for alias, url in cfg.registry_sources.items():
         alias_display = f"[bold]{alias}[/]" if alias == "default" or url == cfg.default_registry_url else alias
         table.add_row(alias_display, url)
     console.print(table)
+
+
+@app.command()
+def remove(
+    alias: str = typer.Argument(..., help="Alias of registry source to remove"),
+) -> None:
+    """Remove a registry source."""
+    cfg_manager = ConfigManager()
+    cfg = cfg_manager.config
+
+    # Check if the source exists
+    if alias not in cfg.registry_sources:
+        console.print(f":x: Registry source '{alias}' not found")
+        raise typer.Exit(1)
+
+    # Prevent removing the default source if it's the only one
+    if alias == "default" and len(cfg.registry_sources) == 1:
+        console.print(":x: Cannot remove the only remaining registry source")
+        raise typer.Exit(1)
+
+    # Remove the source
+    cfg_manager.remove_registry_source(alias)
+    console.print(f":white_check_mark: Removed registry source '{alias}'")

--- a/src/funcn_cli/config_manager.py
+++ b/src/funcn_cli/config_manager.py
@@ -90,6 +90,13 @@ class ConfigManager:
         self._project_cfg.setdefault("registry_sources", {})[alias] = url
         self._save_json(self._project_cfg, self._project_config_path)
 
+    def remove_registry_source(self, alias: str) -> None:
+        # Reload the config from disk first to preserve existing data
+        self._project_cfg = self._load_json(self._project_config_path)
+        if "registry_sources" in self._project_cfg and alias in self._project_cfg["registry_sources"]:
+            del self._project_cfg["registry_sources"][alias]
+            self._save_json(self._project_cfg, self._project_config_path)
+
     def set_default_registry(self, url: str) -> None:
         self._project_cfg["default_registry_url"] = url
         self.add_registry_source("default", url)
@@ -102,11 +109,11 @@ class ConfigManager:
         """Convert funcn.json init format to FuncnConfig format."""
         # Start with a copy of the original config to preserve all fields
         normalized = cfg.copy()
-        
+
         # If it already has new format fields, just ensure consistency
         if "component_paths" in cfg:
             return normalized
-        
+
         # Convert from init format to new format
         # Map directory paths to component_paths
         if "agentDirectory" in cfg or "toolDirectory" in cfg:
@@ -127,7 +134,7 @@ class ConfigManager:
                 component_paths["response_models"] = cfg["responseModelDirectory"]
                 del normalized["responseModelDirectory"]
             normalized["component_paths"] = component_paths
-        
+
         # Map other fields from old to new names
         if "defaultProvider" in cfg:
             normalized["default_provider"] = cfg["defaultProvider"]
@@ -141,9 +148,9 @@ class ConfigManager:
         if "defaultMcpPort" in cfg:
             normalized["default_mcp_port"] = cfg["defaultMcpPort"]
             del normalized["defaultMcpPort"]
-        
+
         # Remove fields that aren't part of FuncnConfig
         normalized.pop("aliases", None)
         normalized.pop("$schema", None)
-            
+
         return normalized

--- a/tests/e2e/test_source_management.py
+++ b/tests/e2e/test_source_management.py
@@ -12,19 +12,21 @@ from unittest.mock import MagicMock, patch
 @pytest.mark.e2e
 class TestSourceManagement(BaseE2ETest):
     """Test registry source management workflows."""
-    
+
     def setup_method(self):
         """Clean up any existing global config before each test."""
         import os
+
         if os.path.exists(".funcnrc.json"):
             os.remove(".funcnrc.json")
-    
+
     def teardown_method(self):
         """Clean up global config after each test."""
         import os
+
         if os.path.exists(".funcnrc.json"):
             os.remove(".funcnrc.json")
-    
+
     @pytest.fixture
     def initialized_project(self, cli_runner, test_project_dir):
         """Create an initialized funcn project."""
@@ -32,98 +34,82 @@ class TestSourceManagement(BaseE2ETest):
         result = self.run_command(cli_runner, ["init", "--yes"], input="n\n", cwd=test_project_dir)
         self.assert_command_success(result)
         return test_project_dir
-    
+
     def test_add_source_project_level(self, cli_runner, initialized_project):
         """Test adding a registry source at project level."""
         # Add a custom source
         result = self.run_command(
-            cli_runner,
-            ["source", "add", "myregistry", "https://myregistry.funcn.ai/index.json"],
-            cwd=initialized_project
+            cli_runner, ["source", "add", "myregistry", "https://myregistry.funcn.ai/index.json"], cwd=initialized_project
         )
-        
+
         self.assert_command_success(result)
-        
+
         # Verify source was added in output
         assert "Added registry source" in result.output
         assert "myregistry" in result.output
-        
+
         # List sources to verify
         result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
         self.assert_command_success(result)
-        
+
         assert "myregistry" in result.output
         assert "https://myregistry.funcn.ai/index.json" in result.output
-    
-    
+
     def test_add_duplicate_source(self, cli_runner, initialized_project):
         """Test adding a source with duplicate alias."""
         # Add a source
         result = self.run_command(
-            cli_runner,
-            ["source", "add", "duplicate", "https://first.funcn.ai/index.json"],
-            cwd=initialized_project
+            cli_runner, ["source", "add", "duplicate", "https://first.funcn.ai/index.json"], cwd=initialized_project
         )
         self.assert_command_success(result)
-        
+
         # Try to add another source with same alias
         result = self.run_command(
-            cli_runner,
-            ["source", "add", "duplicate", "https://second.funcn.ai/index.json"],
-            cwd=initialized_project
+            cli_runner, ["source", "add", "duplicate", "https://second.funcn.ai/index.json"], cwd=initialized_project
         )
-        
+
         # Should either update or warn about duplicate
         assert "duplicate" in result.output.lower() or "updated" in result.output.lower()
-    
+
     def test_list_sources_with_default(self, cli_runner, initialized_project):
         """Test listing sources shows default source."""
         result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
-        
+
         self.assert_command_success(result)
-        
+
         # Should show default source
         assert "default" in result.output
         assert "funcn-ai/funcn-registry" in result.output or "default" in result.output
-    
+
     def test_add_file_source(self, cli_runner, initialized_project):
         """Test adding a local file source."""
         # Create a local index file
         local_index = initialized_project / "local_index.json"
-        local_index.write_text(json.dumps({
-            "registry_version": "1.0.0",
-            "components": []
-        }))
-        
+        local_index.write_text(json.dumps({"registry_version": "1.0.0", "components": []}))
+
         # Add file source
-        result = self.run_command(
-            cli_runner,
-            ["source", "add", "local", f"file://{local_index}"],
-            cwd=initialized_project
-        )
-        
+        result = self.run_command(cli_runner, ["source", "add", "local", f"file://{local_index}"], cwd=initialized_project)
+
         self.assert_command_success(result)
-        
+
         # Verify in list
         result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
         assert "local" in result.output
         assert "file://" in result.output
-    
+
     def test_use_custom_source_for_list(self, cli_runner, initialized_project):
         """Test using a custom source for listing components."""
         # Add custom source
         result = self.run_command(
-            cli_runner,
-            ["source", "add", "custom", "https://custom.funcn.ai/index.json"],
-            cwd=initialized_project
+            cli_runner, ["source", "add", "custom", "https://custom.funcn.ai/index.json"], cwd=initialized_project
         )
         self.assert_command_success(result)
-        
+
         # Verify source was added by listing sources
         result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
         self.assert_command_success(result)
         assert "custom" in result.output
-        
+
         # Mock custom registry response
         custom_registry = {
             "registry_version": "1.0.0",
@@ -133,192 +119,250 @@ class TestSourceManagement(BaseE2ETest):
                     "version": "1.0.0",
                     "type": "agent",
                     "description": "Component from custom registry",
-                    "manifest_path": "components/agents/custom_component/component.json"
+                    "manifest_path": "components/agents/custom_component/component.json",
                 }
-            ]
+            ],
         }
-        
+
         with patch("funcn_cli.core.registry_handler.httpx.Client") as mock_client_class:
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
-            
+
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = custom_registry
             mock_response.raise_for_status = MagicMock()
             mock_client.get.return_value = mock_response
-            
+
             # List from custom source
             result = self.run_command(cli_runner, ["list", "--source", "custom"], cwd=initialized_project)
-            
-                    
+
             self.assert_command_success(result)
-            
+
             # Should show custom component
             assert "custom_component" in result.output
-            
+
             # Verify custom URL was used
             mock_client.get.assert_called()
             call_args = str(mock_client.get.call_args)
             assert "custom.funcn.ai" in call_args
-    
+
     def test_add_source_invalid_url(self, cli_runner, initialized_project):
         """Test adding source with invalid URL format."""
         # Try to add source with invalid URL
-        result = self.run_command(
-            cli_runner,
-            ["source", "add", "invalid", "not-a-valid-url"],
-            cwd=initialized_project
-        )
-        
+        result = self.run_command(cli_runner, ["source", "add", "invalid", "not-a-valid-url"], cwd=initialized_project)
+
         # Should either accept it (trusting user) or validate
         # The behavior depends on implementation
         if result.exit_code != 0:
             assert "invalid" in result.output.lower() or "url" in result.output.lower()
-    
+
     def test_source_persistence(self, cli_runner, initialized_project):
         """Test that sources persist across CLI invocations."""
         # Add a source
         result = self.run_command(
-            cli_runner,
-            ["source", "add", "persistent", "https://persistent.funcn.ai/index.json"],
-            cwd=initialized_project
+            cli_runner, ["source", "add", "persistent", "https://persistent.funcn.ai/index.json"], cwd=initialized_project
         )
         self.assert_command_success(result)
-        
+
         # Create new CLI runner to simulate new session
         new_runner = cli_runner
-        
+
         # List sources in new session
         result = self.run_command(new_runner, ["source", "list"], cwd=initialized_project)
         self.assert_command_success(result)
-        
+
         # Source should still be there
         assert "persistent" in result.output
         assert "https://persistent.funcn.ai/index.json" in result.output
-    
+
     def test_multiple_sources_workflow(self, cli_runner, initialized_project):
         """Test complete workflow with multiple sources."""
         # Add multiple sources
         sources = [
             ("dev", "https://dev.funcn.ai/index.json"),
             ("prod", "https://prod.funcn.ai/index.json"),
-            ("staging", "https://staging.funcn.ai/index.json")
+            ("staging", "https://staging.funcn.ai/index.json"),
         ]
-        
+
         for alias, url in sources:
-            result = self.run_command(
-                cli_runner,
-                ["source", "add", alias, url],
-                cwd=initialized_project
-            )
+            result = self.run_command(cli_runner, ["source", "add", alias, url], cwd=initialized_project)
             self.assert_command_success(result)
-        
+
         # List all sources
         result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
         self.assert_command_success(result)
-        
+
         # All sources should be listed
         for alias, url in sources:
             assert alias in result.output
             assert url in result.output
-        
+
         # Mock different responses for each source
         dev_registry = {
             "registry_version": "1.0.0",
-            "components": [{
-                "name": "dev_component", 
-                "type": "agent", 
-                "version": "1.0.0",
-                "description": "Dev component",
-                "manifest_path": "components/agents/dev_component/component.json"
-            }]
+            "components": [
+                {
+                    "name": "dev_component",
+                    "type": "agent",
+                    "version": "1.0.0",
+                    "description": "Dev component",
+                    "manifest_path": "components/agents/dev_component/component.json",
+                }
+            ],
         }
-        
+
         prod_registry = {
             "registry_version": "1.0.0",
-            "components": [{
-                "name": "prod_component", 
-                "type": "tool", 
-                "version": "2.0.0",
-                "description": "Prod component",
-                "manifest_path": "components/tools/prod_component/component.json"
-            }]
+            "components": [
+                {
+                    "name": "prod_component",
+                    "type": "tool",
+                    "version": "2.0.0",
+                    "description": "Prod component",
+                    "manifest_path": "components/tools/prod_component/component.json",
+                }
+            ],
         }
-        
+
         with patch("funcn_cli.core.registry_handler.httpx.Client") as mock_client_class:
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
-            
+
             def mock_get_side_effect(url, *args, **kwargs):
                 response = MagicMock()
                 response.status_code = 200
                 response.raise_for_status = MagicMock()
-                
+
                 if "dev.funcn.ai" in url:
                     response.json.return_value = dev_registry
                 elif "prod.funcn.ai" in url:
                     response.json.return_value = prod_registry
                 else:
                     response.json.return_value = {"registry_version": "1.0.0", "components": []}
-                
+
                 return response
-            
+
             mock_client.get.side_effect = mock_get_side_effect
-            
+
             # List from dev source
             result = self.run_command(cli_runner, ["list", "--source", "dev"], cwd=initialized_project)
             self.assert_command_success(result)
             assert "dev_component" in result.output
             assert "prod_component" not in result.output
-            
+
             # List from prod source
             result = self.run_command(cli_runner, ["list", "--source", "prod"], cwd=initialized_project)
             self.assert_command_success(result)
             assert "prod_component" in result.output
             assert "dev_component" not in result.output
-    
+
     @pytest.mark.skip(reason="Authentication for registry sources not implemented - tracked in FUNCNOS-36")
     def test_source_with_auth_token(self, cli_runner, initialized_project):
         """Test adding source that requires authentication."""
         # Add source (auth would be handled via headers)
         result = self.run_command(
-            cli_runner,
-            ["source", "add", "private", "https://private.funcn.ai/index.json"],
-            cwd=initialized_project
+            cli_runner, ["source", "add", "private", "https://private.funcn.ai/index.json"], cwd=initialized_project
         )
-        
+
         self.assert_command_success(result)
-        
+
         # When using this source, it should handle auth
         with patch("funcn_cli.core.registry_handler.httpx.Client") as mock_client_class:
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
-            
+
             # Simulate auth required
             mock_unauth_response = MagicMock()
             mock_unauth_response.status_code = 401
             mock_unauth_response.raise_for_status = MagicMock()
-            
+
             mock_auth_response = MagicMock()
             mock_auth_response.status_code = 200
-            mock_auth_response.json.return_value = {
-                "registry_version": "1.0.0",
-                "components": []
-            }
+            mock_auth_response.json.return_value = {"registry_version": "1.0.0", "components": []}
             mock_auth_response.raise_for_status = MagicMock()
-            
+
             # Return different responses based on headers
             def mock_get_side_effect(url, headers=None, *args, **kwargs):
                 if headers and "Authorization" in headers:
                     return mock_auth_response
                 return mock_unauth_response
-            
+
             mock_client.get.side_effect = mock_get_side_effect
-            
+
             # Try to list - implementation should handle auth
             result = self.run_command(cli_runner, ["list", "--source", "private"], cwd=initialized_project)
-            
+
             # Should either succeed (if auth is configured) or show auth error
             if result.exit_code != 0:
                 assert "401" in result.output or "auth" in result.output.lower()
+
+    def test_source_remove(self, cli_runner, initialized_project):
+        """Test removing a registry source."""
+        # Add a custom source
+        result = self.run_command(
+            cli_runner, ["source", "add", "test", "https://test.example.com/index.json"], cwd=initialized_project
+        )
+        self.assert_command_success(result)
+
+        # List sources to verify it was added
+        result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
+        self.assert_command_success(result)
+        assert "test" in result.output
+        assert "https://test.example.com/index.json" in result.output
+
+        # Remove the source
+        result = self.run_command(cli_runner, ["source", "remove", "test"], cwd=initialized_project)
+        self.assert_command_success(result)
+        assert "Removed registry source 'test'" in result.output
+
+        # List sources to verify it was removed
+        result = self.run_command(cli_runner, ["source", "list"], cwd=initialized_project)
+        self.assert_command_success(result)
+        assert "test" not in result.output
+        assert "https://test.example.com/index.json" not in result.output
+
+    def test_source_remove_nonexistent(self, cli_runner, initialized_project):
+        """Test removing a non-existent registry source."""
+        # Try to remove a non-existent source
+        result = self.run_command(cli_runner, ["source", "remove", "nonexistent"], cwd=initialized_project)
+        assert result.exit_code == 1
+        assert "Registry source 'nonexistent' not found" in result.output
+
+    def test_source_remove_default_when_only_source(self, cli_runner, initialized_project):
+        """Test preventing removal of the only remaining source."""
+        # Try to remove default source when it's the only one
+        result = self.run_command(cli_runner, ["source", "remove", "default"], cwd=initialized_project)
+        assert result.exit_code == 1
+        assert "Cannot remove the only remaining registry source" in result.output
+
+    def test_source_add_url_validation(self, cli_runner, initialized_project):
+        """Test URL validation when adding sources."""
+        # Test invalid scheme
+        result = self.run_command(
+            cli_runner, ["source", "add", "invalid", "ftp://example.com/index.json"], cwd=initialized_project
+        )
+        assert result.exit_code == 1
+        assert "Invalid URL scheme" in result.output
+        assert "ftp" in result.output
+
+        # Test missing domain
+        result = self.run_command(cli_runner, ["source", "add", "nodomain", "https://"], cwd=initialized_project)
+        assert result.exit_code == 1
+        assert "missing domain/host" in result.output
+
+        # Test warning for non-index.json URL
+        result = self.run_command(
+            cli_runner, ["source", "add", "nonindex", "https://example.com/registry"], cwd=initialized_project
+        )
+        self.assert_command_success(result)
+        assert "should typically point to an index.json file" in result.output
+        assert "Added registry source" in result.output
+
+        # Test valid index.json URL
+        result = self.run_command(
+            cli_runner, ["source", "add", "proper", "https://example.com/index.json"], cwd=initialized_project
+        )
+        self.assert_command_success(result)
+        assert "Added registry source" in result.output
+        assert "should typically point to an index.json file" not in result.output

--- a/tests/unit/commands/test_source.py
+++ b/tests/unit/commands/test_source.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from funcn_cli.commands.source import add, list_sources
+import typer
+from funcn_cli.commands.source import add, list_sources, remove
 from funcn_cli.config_manager import FuncnConfig
 from unittest.mock import MagicMock
 
@@ -14,7 +15,9 @@ class TestSource:
     @pytest.fixture
     def mock_config_manager(self, mocker):
         """Mock ConfigManager."""
-        return mocker.patch("funcn_cli.commands.source.cfg_manager")
+        mock_cfg_manager = MagicMock()
+        mocker.patch("funcn_cli.commands.source.ConfigManager", return_value=mock_cfg_manager)
+        return mock_cfg_manager
 
     @pytest.fixture
     def mock_console(self, mocker):
@@ -38,12 +41,10 @@ class TestSource:
     def test_add_source_project_level(self, mock_config_manager, mock_console):
         """Test adding a registry source at project level."""
         # Execute
-        add(alias="test", url="https://test.com/index.json", global_cfg=False)
+        add(alias="test", url="https://test.com/index.json")
 
         # Verify
-        mock_config_manager.add_registry_source.assert_called_once_with(
-            "test", "https://test.com/index.json", project_level=True
-        )
+        mock_config_manager.add_registry_source.assert_called_once_with("test", "https://test.com/index.json")
         mock_console.print.assert_called_once()
         printed_msg = str(mock_console.print.call_args[0][0])
         assert "Added registry source 'test' -> https://test.com/index.json" in printed_msg
@@ -51,12 +52,10 @@ class TestSource:
     def test_add_source_global_level(self, mock_config_manager, mock_console):
         """Test adding a registry source at global level."""
         # Execute
-        add(alias="global_test", url="https://global.com/index.json", global_cfg=True)
+        add(alias="global_test", url="https://global.com/index.json")
 
         # Verify
-        mock_config_manager.add_registry_source.assert_called_once_with(
-            "global_test", "https://global.com/index.json", project_level=False
-        )
+        mock_config_manager.add_registry_source.assert_called_once_with("global_test", "https://global.com/index.json")
         mock_console.print.assert_called_once()
         printed_msg = str(mock_console.print.call_args[0][0])
         assert "Added registry source 'global_test' -> https://global.com/index.json" in printed_msg
@@ -64,22 +63,18 @@ class TestSource:
     def test_add_source_with_special_characters(self, mock_config_manager, mock_console):
         """Test adding a source with special characters in alias."""
         # Execute
-        add(alias="test-source_123", url="https://test.com/index.json", global_cfg=False)
+        add(alias="test-source_123", url="https://test.com/index.json")
 
         # Verify
-        mock_config_manager.add_registry_source.assert_called_once_with(
-            "test-source_123", "https://test.com/index.json", project_level=True
-        )
+        mock_config_manager.add_registry_source.assert_called_once_with("test-source_123", "https://test.com/index.json")
 
     def test_add_source_with_file_url(self, mock_config_manager, mock_console):
         """Test adding a source with file:// URL."""
         # Execute
-        add(alias="local", url="file:///home/user/registry/index.json", global_cfg=False)
+        add(alias="local", url="file:///home/user/registry/index.json")
 
         # Verify
-        mock_config_manager.add_registry_source.assert_called_once_with(
-            "local", "file:///home/user/registry/index.json", project_level=True
-        )
+        mock_config_manager.add_registry_source.assert_called_once_with("local", "file:///home/user/registry/index.json")
 
     def test_list_sources_with_multiple_sources(self, mock_config_manager, mock_console, sample_config):
         """Test listing multiple registry sources."""
@@ -140,7 +135,7 @@ class TestSource:
         # Verify default is marked
         default_found = False
         for row in captured_rows:
-            if "(default)" in row[0]:
+            if "[bold]default[/]" in row[0] or row[0] == "default":
                 default_found = True
                 # Verify it's pointing to the correct URL
                 assert sample_config.default_registry_url in row[1]
@@ -201,10 +196,10 @@ class TestSource:
             mock_console.print.reset_mock()
 
             # Execute
-            add(alias=f"test{i}", url=url, global_cfg=False)
+            add(alias=f"test{i}", url=url)
 
             # Verify
-            mock_config_manager.add_registry_source.assert_called_once_with(f"test{i}", url, project_level=True)
+            mock_config_manager.add_registry_source.assert_called_once_with(f"test{i}", url)
 
     def test_add_source_error_handling(self, mock_config_manager, mock_console):
         """Test error handling when adding a source fails."""
@@ -213,7 +208,7 @@ class TestSource:
 
         # Execute and verify exception is raised
         with pytest.raises(Exception, match="Failed to add source"):
-            add(alias="error_test", url="https://test.com/index.json", global_cfg=False)
+            add(alias="error_test", url="https://test.com/index.json")
 
     def test_list_sources_with_long_urls(self, mock_config_manager, mock_console):
         """Test listing sources with very long URLs."""
@@ -234,3 +229,178 @@ class TestSource:
 
         # Verify table was printed without errors
         assert mock_console.print.called
+
+    def test_remove_source_success(self, mock_config_manager, mock_console):
+        """Test successfully removing a registry source."""
+        # Setup
+        config = FuncnConfig(
+            default_registry_url="https://example.com/index.json",
+            registry_sources={
+                "default": "https://example.com/index.json",
+                "custom": "https://custom.com/index.json",
+                "local": "file:///path/to/local/index.json",
+            },
+            component_paths={},
+        )
+        mock_config_manager.config = config
+
+        # Execute
+        remove(alias="custom")
+
+        # Verify
+        mock_config_manager.remove_registry_source.assert_called_once_with("custom")
+        mock_console.print.assert_called_once()
+        printed_msg = str(mock_console.print.call_args[0][0])
+        assert "Removed registry source 'custom'" in printed_msg
+
+    def test_remove_source_not_found(self, mock_config_manager, mock_console):
+        """Test removing a non-existent registry source."""
+        # Setup
+        config = FuncnConfig(
+            default_registry_url="https://example.com/index.json",
+            registry_sources={
+                "default": "https://example.com/index.json",
+            },
+            component_paths={},
+        )
+        mock_config_manager.config = config
+
+        # Execute and verify exception is raised
+        with pytest.raises(typer.Exit) as exc_info:
+            remove(alias="nonexistent")
+
+        assert exc_info.value.exit_code == 1
+        mock_console.print.assert_called_once()
+        printed_msg = str(mock_console.print.call_args[0][0])
+        assert "Registry source 'nonexistent' not found" in printed_msg
+
+    def test_remove_last_remaining_source(self, mock_config_manager, mock_console):
+        """Test preventing removal of the only remaining registry source."""
+        # Setup
+        config = FuncnConfig(
+            default_registry_url="https://example.com/index.json",
+            registry_sources={
+                "default": "https://example.com/index.json",
+            },
+            component_paths={},
+        )
+        mock_config_manager.config = config
+
+        # Execute and verify exception is raised
+        with pytest.raises(typer.Exit) as exc_info:
+            remove(alias="default")
+
+        assert exc_info.value.exit_code == 1
+        mock_console.print.assert_called_once()
+        printed_msg = str(mock_console.print.call_args[0][0])
+        assert "Cannot remove the only remaining registry source" in printed_msg
+
+    def test_remove_source_with_multiple_sources(self, mock_config_manager, mock_console):
+        """Test removing a source when multiple sources exist."""
+        # Setup
+        config = FuncnConfig(
+            default_registry_url="https://example.com/index.json",
+            registry_sources={
+                "default": "https://example.com/index.json",
+                "backup": "https://backup.com/index.json",
+                "test": "https://test.com/index.json",
+            },
+            component_paths={},
+        )
+        mock_config_manager.config = config
+
+        # Execute
+        remove(alias="test")
+
+        # Verify
+        mock_config_manager.remove_registry_source.assert_called_once_with("test")
+        mock_console.print.assert_called_once()
+        printed_msg = str(mock_console.print.call_args[0][0])
+        assert "Removed registry source 'test'" in printed_msg
+
+    def test_remove_default_source_with_other_sources(self, mock_config_manager, mock_console):
+        """Test that default source can be removed if other sources exist."""
+        # Setup
+        config = FuncnConfig(
+            default_registry_url="https://example.com/index.json",
+            registry_sources={
+                "default": "https://example.com/index.json",
+                "alternative": "https://alternative.com/index.json",
+            },
+            component_paths={},
+        )
+        mock_config_manager.config = config
+
+        # Execute - should succeed since there's another source
+        remove(alias="default")
+
+        # Verify
+        mock_config_manager.remove_registry_source.assert_called_once_with("default")
+        mock_console.print.assert_called_once()
+        printed_msg = str(mock_console.print.call_args[0][0])
+        assert "Removed registry source 'default'" in printed_msg
+
+    def test_add_source_invalid_scheme(self, mock_config_manager, mock_console):
+        """Test adding source with invalid URL scheme."""
+        # Execute and verify exception is raised
+        with pytest.raises(typer.Exit) as exc_info:
+            add(alias="invalid", url="ftp://example.com/index.json")
+
+        assert exc_info.value.exit_code == 1
+        mock_console.print.assert_called()
+        printed_msg = str(mock_console.print.call_args[0][0])
+        assert "Invalid URL scheme" in printed_msg
+        assert "ftp" in printed_msg
+
+    def test_add_source_missing_domain(self, mock_config_manager, mock_console):
+        """Test adding source with missing domain."""
+        # Execute and verify exception is raised
+        with pytest.raises(typer.Exit) as exc_info:
+            add(alias="nodomain", url="https://")
+
+        assert exc_info.value.exit_code == 1
+        mock_console.print.assert_called()
+        printed_msg = str(mock_console.print.call_args[0][0])
+        assert "missing domain/host" in printed_msg
+
+    def test_add_source_warns_non_index_url(self, mock_config_manager, mock_console):
+        """Test warning when URL doesn't end with index.json."""
+        # Execute - should succeed but warn
+        add(alias="nonindex", url="https://example.com/registry")
+
+        # Should have two print calls - warning and success
+        assert mock_console.print.call_count == 2
+        warning_msg = str(mock_console.print.call_args_list[0][0][0])
+        success_msg = str(mock_console.print.call_args_list[1][0][0])
+
+        assert "should typically point to an index.json file" in warning_msg
+        assert "Added registry source" in success_msg
+
+        # Should still add the source
+        mock_config_manager.add_registry_source.assert_called_once_with("nonindex", "https://example.com/registry")
+
+    def test_add_source_accepts_index_json(self, mock_config_manager, mock_console):
+        """Test that URL ending with index.json doesn't warn."""
+        # Execute
+        add(alias="proper", url="https://example.com/index.json")
+
+        # Should only have one print call (success, no warning)
+        assert mock_console.print.call_count == 1
+        success_msg = str(mock_console.print.call_args[0][0])
+        assert "Added registry source" in success_msg
+
+        # Should add the source
+        mock_config_manager.add_registry_source.assert_called_once_with("proper", "https://example.com/index.json")
+
+    def test_add_source_accepts_file_scheme(self, mock_config_manager, mock_console):
+        """Test that file:// URLs are accepted."""
+        # Execute
+        add(alias="local", url="file:///path/to/index.json")
+
+        # Should succeed
+        assert mock_console.print.call_count == 1
+        success_msg = str(mock_console.print.call_args[0][0])
+        assert "Added registry source" in success_msg
+
+        # Should add the source
+        mock_config_manager.add_registry_source.assert_called_once_with("local", "file:///path/to/index.json")


### PR DESCRIPTION
## Summary
- Add remove subcommand to delete registry sources
- Add URL validation when adding sources
- Add comprehensive tests for source management

## Changes
- Implemented `funcn source remove` subcommand to remove registry sources
- Added validation to prevent removal of the only remaining source
- Implemented URL validation for http/https/file schemes
- Added domain/host validation for http/https URLs
- Added warning when URL doesn't end with index.json
- Added comprehensive unit tests for all new functionality
- Added E2E tests for remove command and URL validation

## Test plan
- [x] Unit tests for remove command (5 tests)
- [x] Unit tests for URL validation (5 tests)  
- [x] E2E tests for remove command (3 tests)
- [x] E2E test for URL validation
- [x] All existing tests pass

Closes FUNCNOS-29