### PR TITLE
Fix failing E2E tests due to HTTP client mocking issues

### DIFF
--- a/.claude/commands/INDEX.md
+++ b/.claude/commands/INDEX.md
@@ -7,6 +7,7 @@ CLAUDE COMMANDS - QUICK INDEX
 - `/project:daily-check` - Daily development status check
 - `/project:debug-systematic` - Scientific debugging with root cause analysis
 - `/project:pr-complete` - Create professional pull requests
+- `/project:context-compact` - Prepare context summary before compaction
 
 ## Quality & Testing Commands
 

--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -33,6 +33,7 @@ Powerful, compact custom slash commands for Claude Code using advanced prompt en
 
 - `/project:linear-feature` - **Linear Workflow Expert** for feature implementation
 - `/project:pr-complete` - **PR Craftsman** creating perfect pull requests
+- `/project:context-compact` - **Context Preservation Specialist** for seamless continuation
 
 ## Usage
 
@@ -193,6 +194,14 @@ claude > /project:crawl-docs https://docs.example.com
 - Comprehensive change analysis
 - Context extraction and summary
 - Review-ready pull requests
+
+#### `/project:context-compact`
+
+**Context Preservation Specialist** for long tasks.
+
+- Distills work state to essentials
+- Preserves critical technical context
+- Ensures seamless continuation after compaction
 
 ## Creating New Commands
 

--- a/.claude/commands/context-compact.md
+++ b/.claude/commands/context-compact.md
@@ -1,0 +1,81 @@
+Prepare context for compaction: $ARGUMENTS
+
+<ultrathink>
+Context window approaching limit. Need to preserve essential information for task continuation.
+</ultrathink>
+
+<megaexpertise type="context-preservation-specialist">
+Distill current work state to essential elements. Capture critical context for seamless continuation after compaction.
+</megaexpertise>
+
+<context>
+Working on: $ARGUMENTS
+Need to compact context while preserving task continuity
+</context>
+
+<requirements>
+- Summarize work completed so far
+- Identify what remains to be done
+- Preserve critical technical context
+- Maintain references to key files/issues
+- Note any pending decisions or blockers
+</requirements>
+
+<actions>
+1. Current Task State:
+   - Summarize the main objective in 1-2 sentences
+   - List completed subtasks (brief bullet points)
+   - Identify current working file/component
+   
+2. Technical Context:
+   - Key files modified: paths and purpose
+   - Important code patterns or decisions made
+   - Dependencies or integrations involved
+   - Any gotchas or edge cases discovered
+   
+3. Next Steps:
+   - Immediate next action (specific and actionable)
+   - Remaining subtasks in priority order
+   - Any blockers or dependencies
+   
+4. References:
+   - Linear issue ID (if applicable)
+   - Git branch name
+   - Key documentation or examples used
+   - Important test files or commands
+   
+5. Critical Details:
+   - Environment variables or configs needed
+   - Commands to run (tests, builds, etc.)
+   - Any temporary workarounds in place
+   - Decisions that need to be made
+</actions>
+
+Format output as:
+```
+## Task: [Brief description]
+
+### Completed:
+- [Item 1]
+- [Item 2]
+
+### Next Action:
+[Specific next step with file path if applicable]
+
+### Remaining Work:
+1. [Task 1]
+2. [Task 2]
+
+### Key Context:
+- Files: [path1], [path2]
+- Branch: [branch-name]
+- Issue: [LINEAR-123]
+- Commands: [test command], [build command]
+
+### Notes:
+[Any critical information for continuation]
+```
+
+This ensures smooth continuation after context reset. Focus on what's essential for picking up exactly where we left off.
+
+Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.

--- a/tests/e2e/test_add_workflow.py
+++ b/tests/e2e/test_add_workflow.py
@@ -25,8 +25,10 @@ class TestAddWorkflow(BaseE2ETest):
     def test_add_component_by_name(self, cli_runner, initialized_project, mock_registry_response, mock_component_manifest):
         """Test adding a component by name from the registry."""
         with patch("httpx.Client") as mock_client_class:
-            # Create mock client instance
+            # Create mock client instance with context manager support
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
             # Mock registry index request
@@ -105,8 +107,10 @@ def test_agent(question: str): ...
     def test_add_component_with_dependencies(self, cli_runner, initialized_project, mock_registry_response, mock_component_manifest):
         """Test adding a component with Python dependencies - verify dependency message is shown."""
         with patch("httpx.Client") as mock_client_class:
-            # Create mock client instance
+            # Create mock client instance with context manager support
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
             # Mock registry index request
@@ -161,8 +165,10 @@ def test_agent(question: str): ...
     def test_add_multiple_components(self, cli_runner, initialized_project, mock_registry_response, mock_component_manifest):
         """Test adding multiple components in sequence."""
         with patch("httpx.Client") as mock_client_class:
-            # Create mock client instance
+            # Create mock client instance with context manager support
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
             # Create a second component manifest for tools
@@ -274,8 +280,10 @@ def test_tool(input: str) -> str:
     def test_add_component_already_exists(self, cli_runner, initialized_project, mock_registry_response, mock_component_manifest):
         """Test adding a component that already exists."""
         with patch("httpx.Client") as mock_client_class:
-            # Create mock client instance
+            # Create mock client instance with context manager support
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
             # Mock component file downloads
@@ -334,9 +342,11 @@ def test_tool(input: str) -> str:
         """Test adding a specific version of a component."""
         with patch("funcn_cli.core.registry_handler.httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
-            def mock_get_side_effect(url):
+            def mock_get_side_effect(url, *args, **kwargs):
                 if "index.json" in url:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
@@ -383,6 +393,8 @@ def test_tool(input: str) -> str:
             result = self.run_command(cli_runner, ["add", "--provider", "openai", "--model", "gpt-4o-mini", "--stream", "test-agent@1.0.0"], input="n\nn\n")
 
             # Version handling should be mentioned
+            if result.exit_code != 0:
+                print(f"Test failed with output: {result.output}")
             assert result.exit_code == 0
             assert "test-agent" in result.output
             assert "added successfully" in result.output
@@ -401,9 +413,11 @@ def test_tool(input: str) -> str:
         """Test adding a specific version that doesn't exist."""
         with patch("funcn_cli.core.registry_handler.httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
-            def mock_get_side_effect(url):
+            def mock_get_side_effect(url, *args, **kwargs):
                 if "index.json" in url:
                     mock_response = MagicMock()
                     mock_response.status_code = 200
@@ -425,8 +439,10 @@ def test_tool(input: str) -> str:
     def test_add_nonexistent_component(self, cli_runner, initialized_project, mock_registry_response):
         """Test adding a component that doesn't exist."""
         with patch("httpx.Client") as mock_client_class:
-            # Create mock client instance
+            # Create mock client instance with context manager support
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
             # Set up mock responses
@@ -455,8 +471,10 @@ def test_tool(input: str) -> str:
     def test_add_component_network_error(self, cli_runner, initialized_project):
         """Test handling network errors when adding components."""
         with patch("httpx.Client") as mock_client_class:
-            # Create mock client instance
+            # Create mock client instance with context manager support
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
             # Simulate network error
@@ -480,8 +498,10 @@ def test_tool(input: str) -> str:
     def test_add_component_from_url(self, cli_runner, initialized_project):
         """Test adding a component directly from URL."""
         with patch("httpx.Client") as mock_client_class:
-            # Create mock client instance
+            # Create mock client instance with context manager support
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
 
             # Mock component manifest

--- a/tests/e2e/test_list_search_workflow.py
+++ b/tests/e2e/test_list_search_workflow.py
@@ -74,6 +74,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test listing all components from registry."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -103,12 +105,14 @@ class TestListSearchWorkflow(BaseE2ETest):
         
         result = self.run_command(
             cli_runner,
-            ["source", "add", "custom", "https://custom.funcn.ai/index.json"]
+            ["source", "add", "custom", "https://custom.funcn.ai/index.json", "--skip-check"]
         )
         self.assert_command_success(result)
         
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -129,6 +133,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test searching components by name."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -150,6 +156,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test searching components by description."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -168,6 +176,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test that search is case insensitive."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -181,6 +191,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test search with no matching results."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -200,6 +212,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         }
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(empty_registry)
             
@@ -214,6 +228,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test handling network errors when listing."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.side_effect = Exception("Network error")
             
@@ -226,6 +242,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test searching with special characters."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -241,6 +259,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test that list command shows component versions."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             
@@ -257,6 +277,8 @@ class TestListSearchWorkflow(BaseE2ETest):
         """Test searching components by tag."""
         with patch("httpx.Client") as mock_client_class:
             mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=None)
             mock_client_class.return_value = mock_client
             mock_client.get.return_value = self._mock_registry_response(mock_registry_with_many_components)
             

--- a/tests/fixtures/sample_components.py
+++ b/tests/fixtures/sample_components.py
@@ -1,7 +1,7 @@
 """Sample component fixtures for testing the component system."""
 
 import json
-from funcn_cli.core.models import Component, ComponentConfig, ComponentFile, DependencySpec
+from funcn_cli.core.models import ComponentManifest, RegistryComponentEntry
 from pathlib import Path
 
 


### PR DESCRIPTION
## Summary
- Fixed httpx.Client mock to support context manager pattern
- Updated mock functions to accept headers parameter
- All 80 E2E tests now passing

## Problem
The E2E tests were failing because:
1. httpx.Client mock didn't handle context manager pattern (`__enter__`/`__exit__`)
2. Mock functions didn't accept headers parameter sent by cache system
3. Some tests needed `--skip-check` flag for source add commands

## Solution
- Added `__enter__` and `__exit__` methods to httpx.Client mocks
- Updated mock functions to accept `*args, **kwargs`
- Added `--skip-check` flag where needed

## Test Results
```
============================== 80 passed, 1 skipped in 0.90s ==============================
```

## Related
- Fixes #70
- Linear issue: FUNCNOS-46