### PR TITLE
fix: Rename metadata field to agent_metadata in SQLAlchemy tool

### DIFF
--- a/packages/funcn_registry/components/tools/sqlalchemy_db/tool.py
+++ b/packages/funcn_registry/components/tools/sqlalchemy_db/tool.py
@@ -49,7 +49,7 @@ class AgentState(Base):
     data_type = Column(String(50), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False, index=True)
-    metadata = Column(Text)
+    agent_metadata = Column(Text)
 
     __table_args__ = (
         UniqueConstraint('agent_id', 'conversation_id', 'key', name='uq_agent_conv_key'),
@@ -231,7 +231,7 @@ async def store_agent_state(
                 # Update existing record
                 existing.value = value_json
                 existing.data_type = data_type
-                existing.metadata = metadata_json
+                existing.agent_metadata = metadata_json
                 existing.updated_at = datetime.utcnow()
                 rows_affected = 1
             else:
@@ -242,7 +242,7 @@ async def store_agent_state(
                     key=key,
                     value=value_json,
                     data_type=data_type,
-                    metadata=metadata_json,
+                    agent_metadata=metadata_json,
                 )
                 session.add(new_state)
                 rows_affected = 1
@@ -313,15 +313,15 @@ async def get_agent_state(
                     'data_type': record.data_type,
                     'created_at': record.created_at.isoformat(),
                     'updated_at': record.updated_at.isoformat(),
-                    'metadata': record.metadata,
+                    'metadata': record.agent_metadata,
                 }
 
                 # Deserialize JSON values
                 try:
                     if record.data_type != 'str':
                         data['value'] = json.loads(record.value)
-                    if record.metadata:
-                        data['metadata'] = json.loads(record.metadata)
+                    if record.agent_metadata:
+                        data['metadata'] = json.loads(record.agent_metadata)
                 except json.JSONDecodeError:
                     pass
 
@@ -448,15 +448,15 @@ async def query_agent_history(
                     'data_type': record.data_type,
                     'created_at': record.created_at.isoformat(),
                     'updated_at': record.updated_at.isoformat(),
-                    'metadata': record.metadata,
+                    'metadata': record.agent_metadata,
                 }
 
                 # Deserialize JSON values
                 try:
                     if record.data_type != 'str':
                         data['value'] = json.loads(record.value)
-                    if record.metadata:
-                        data['metadata'] = json.loads(record.metadata)
+                    if record.agent_metadata:
+                        data['metadata'] = json.loads(record.agent_metadata)
                 except json.JSONDecodeError:
                     pass
 


### PR DESCRIPTION
## Summary
- Fixed SQLAlchemy reserved attribute error by renaming `metadata` field to `agent_metadata`
- Resolves test failures in `test_dnd_5e_api.py` caused by SQLAlchemy InvalidRequestError

## Context
SQLAlchemy reserves the 'metadata' attribute name when using the Declarative API. This was causing the error:
```
sqlalchemy.exc.InvalidRequestError: Attribute name 'metadata' is reserved when using the Declarative API
```

## Changes
- Renamed the `metadata` column to `agent_metadata` in the `AgentState` model
- Updated all references throughout the tool to use the new field name
- Maintained backward compatibility by keeping the key as 'metadata' in the returned dictionaries

## Test Results
- The SQLAlchemy error is now resolved
- Tests can now properly initialize the SQLAlchemy models without conflicts

Related to FUNCNOS-7: [Testing] Systematic Testing of All Agents and Tools